### PR TITLE
Add IDemoralizeHandler

### DIFF
--- a/TabletopTweaks-Core/NewEvents/IDemoralizeHandler.cs
+++ b/TabletopTweaks-Core/NewEvents/IDemoralizeHandler.cs
@@ -17,7 +17,7 @@ namespace TabletopTweaks.Core.NewEvents {
     /// <summary>
     /// Event handler for the Demoralize action.
     /// </summary>
-    public interface IDemoralizeHandler : IGlobalSubscriber {
+    public interface IInitiatorDemoralizeHandler : IUnitSubscriber {
         /// <summary>
         /// Fires at the end of Demoralize.RunAction() if the intimidate check is successful.
         /// </summary>
@@ -42,7 +42,8 @@ namespace TabletopTweaks.Core.NewEvents {
         internal static class Demoralize_RunAction {
             private static void NotifyIntimidateSuccess(
                 Demoralize action, RuleSkillCheck intimidateCheck, Buff appliedBuff) {
-                EventBus.RaiseEvent<IDemoralizeHandler>(
+                EventBus.RaiseEvent<IInitiatorDemoralizeHandler>(
+                    action.Context?.MaybeCaster,
                     h => h.AfterIntimidateSuccess(action, intimidateCheck, appliedBuff));
             }
 

--- a/TabletopTweaks-Core/NewEvents/IDemoralizeHandler.cs
+++ b/TabletopTweaks-Core/NewEvents/IDemoralizeHandler.cs
@@ -1,0 +1,124 @@
+﻿using HarmonyLib;
+using Kingmaker.Controllers.Dialog;
+using Kingmaker.Designers;
+using Kingmaker.PubSubSystem;
+using Kingmaker.RuleSystem.Rules;
+using Kingmaker.UnitLogic.Buffs;
+using Kingmaker.UnitLogic.Mechanics;
+using Kingmaker.UnitLogic.Mechanics.Actions;
+using Kingmaker.Utility;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using static TabletopTweaks.Core.Main;
+
+namespace TabletopTweaks.Core.NewEvents {
+    /// <summary>
+    /// Event handler for the Demoralize action.
+    /// </summary>
+    public interface IDemoralizeHandler : IGlobalSubscriber {
+        /// <summary>
+        /// Fires at the end of Demoralize.RunAction() if the intimidate check is successful.
+        /// </summary>
+        /// 
+        /// <remarks>
+        /// <para>
+        /// The <paramref name="appliedBuff"/> will be either GreaterBuff or Buff. It does not represent other buffs
+        /// applied, e.g. ShatterConfidenceBuff. If GreaterBuff is applied by FrighteningThug, appliedBuff will be
+        /// Buff.
+        /// </para>
+        /// 
+        /// <para>
+        /// If <paramref name="appliedBuff"/> is null it likely means the target is immune to GreaterBuff or Buff.
+        /// </para>
+        /// </remarks>
+        /// 
+        /// <param name="intimidateCheck">The triggered skill check</param>
+        /// <param name="appliedBuff">The buff applied, or null if none was applied</param>
+        void AfterIntimidateSuccess(Demoralize action, RuleSkillCheck intimidateCheck, Buff appliedBuff);
+
+        [HarmonyPatch(typeof(Demoralize))]
+        internal static class Demoralize_RunAction {
+            private static void NotifyIntimidateSuccess(
+                Demoralize action, RuleSkillCheck intimidateCheck, Buff appliedBuff) {
+                EventBus.RaiseEvent<IDemoralizeHandler>(
+                    h => h.AfterIntimidateSuccess(action, intimidateCheck, appliedBuff));
+            }
+
+            static readonly MethodInfo RuleStatCheck_Success =
+                AccessTools.PropertyGetter(typeof(RuleStatCheck), nameof(RuleStatCheck.Success));
+            static readonly MethodInfo Buff_StoreFact = AccessTools.Method(typeof(Buff), nameof(Buff.StoreFact));
+
+            [HarmonyPatch(nameof(Demoralize.RunAction)), HarmonyTranspiler]
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator il) {
+                try {
+                    var code = new List<CodeInstruction>(instructions);
+                    Label newJumpTarget = il.DefineLabel();
+
+                    // Search backwards for the last Leave_S instruction which is the insertion point.
+                    var index = code.Count - 1;
+                    var insertionIndex = 0;
+                    var leaveLabel = new List<Label>();
+                    for (; index >= 0; index--) {
+                        if (code[index].opcode == OpCodes.Leave_S) {
+                            insertionIndex = index;
+                            leaveLabel = code[index].labels;
+                            break;
+                        }
+                    }
+                    if (insertionIndex == 0) {
+                        throw new InvalidOperationException("Missing demoralize transpiler insertion index.");
+                    }
+
+                    CodeInstruction loadIntimidateCheck = null;
+                    CodeInstruction loadAppliedBuff = null;
+
+                    // Keep searching backwards to find the load statements and redirect jumps to leaveLabel or
+                    // retLabel to newJumpTarget.
+                    index--; // Make sure not to change the last Leave_S jump or it will be an infinite loop
+                    for (; index >= 0; index--) {
+                        if (code[index].Calls(RuleStatCheck_Success)) {
+                            // Statement before Success must load the skill check
+                            loadIntimidateCheck = code[index - 1].Clone();
+                            break; // Don't mess w/ jumps before the skill check result is generated
+                        }
+
+                        if (code[index].Calls(Buff_StoreFact)) {
+                            // Statement before StoreFact is loading the fact being stored, statement before that is
+                            // loading the buff
+                            loadAppliedBuff = code[index - 2].Clone();
+                        }
+
+                        // Any operand which is a Label is a jump
+                        if (code[index].operand is Label jumpTarget) {
+                            if (leaveLabel.Contains(jumpTarget)) {
+                                code[index].operand = newJumpTarget;
+                            }
+                        }
+                    }
+
+                    if (loadIntimidateCheck is null) {
+                        throw new InvalidOperationException("Missing intimidate check load instruction.");
+                    }
+                    if (loadAppliedBuff is null) {
+                        throw new InvalidOperationException("Missing applied buff load instruction.");
+                    }
+
+                    var newCode = new List<CodeInstruction>() {
+                        new CodeInstruction(OpCodes.Ldarg_0).WithLabels(newJumpTarget), // Loads this (action) 
+                        loadIntimidateCheck,
+                        loadAppliedBuff,
+                        CodeInstruction.Call(
+                            typeof(Demoralize_RunAction), nameof(Demoralize_RunAction.NotifyIntimidateSuccess)),
+                    };
+                    code.InsertRange(insertionIndex, newCode);
+                    return code;
+                } catch (Exception e) {
+                    TTTContext.Logger.LogError(e, "Demoralize transpiler failed.");
+                    return instructions;
+                }
+            }
+        }
+    }
+}

--- a/TabletopTweaks-Core/TabletopTweaks-Core.csproj
+++ b/TabletopTweaks-Core/TabletopTweaks-Core.csproj
@@ -202,6 +202,7 @@
     <Compile Include="NewEvents\IActivatableAbilityGetCommandTypeHandler.cs" />
     <Compile Include="NewEvents\IAddModifierHandler.cs" />
     <Compile Include="NewEvents\ICriticalRangeCalculatedHandler.cs" />
+    <Compile Include="NewEvents\IDemoralizeHandler.cs" />
     <Compile Include="NewEvents\IStatBonusCalculatedHandler.cs" />
     <Compile Include="NewEvents\IBlueprintCacheInitHandler.cs" />
     <Compile Include="NewEvents\ILocaleChangedHandler.cs" />


### PR DESCRIPTION
A transpiler similar to the TTT-Rework Trickster Persuasion transpiler (https://github.com/Vek17/TabletopTweaks-Reworks/blob/master/TabletopTweaks-Reworks/Patches/Trickster.cs#L731).

Designed w/ compatibility in mind, it only exposes intimidate success because implementing it for both success and failure could affect the Trickster path. Additionally I couldn't find any pf 1e options that did anything on demoralize failure so it probably isn't needed.

Tested:
-Using my implementation of Hurtful in an as-yet-to-be-released mod
-With and without TTT-Rework installed