### PR TITLE
Load TTT-Core after MewsiferConsole.Mod

### DIFF
--- a/TabletopTweaks-Core/Info.json
+++ b/TabletopTweaks-Core/Info.json
@@ -9,5 +9,6 @@
   "ManagerVersion": "0.23.0",
   "Repository": "https://raw.githubusercontent.com/Vek17/TabletopTweaks-Core/master/Repository.json",
   "Requirements": [],
+  "LoadAfter": ["MewsiferConsole.Mod"],
   "Version": "0.4.3"
 }


### PR DESCRIPTION
It's not a requirement so it won't have any impact if user does not have MewsiferConsole.Mod installed. However, if it is installed this guarantees all TTT-Core mod logs during startup are logged to the console.

MewsiferConsole is functional right now but there's a few things Bubbles & I are working on before official release targeting Sunday. Just wanted to get this in before the next TTT-Core release.