### PR TITLE
add support for descriptor immunity ignore

### DIFF
--- a/TabletopTweaks-Core/NewComponents/BuffDescriptorImmunityAgainstAlignment.cs
+++ b/TabletopTweaks-Core/NewComponents/BuffDescriptorImmunityAgainstAlignment.cs
@@ -9,6 +9,7 @@ using Kingmaker.RuleSystem.Rules;
 using Kingmaker.UnitLogic;
 using Kingmaker.UnitLogic.Mechanics;
 using Kingmaker.Utility;
+using TabletopTweaks.Core.NewUnitParts;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -49,13 +50,22 @@ namespace TabletopTweaks.Core.NewComponents {
             if ((maybeCaster != null) ? maybeCaster.State.Features.MythicReduceResistances : null) {
                 return false;
             }
-            bool buffHasDescriptor = this.Descriptor.HasAnyFlag(context.SpellDescriptor);
+            bool buffHasDescriptor = GetWorkingImmunities().HasAnyFlag(context.SpellDescriptor);
             bool noCaster = context.MaybeCaster == null;
             bool noImmunityBypassFeature = this.IgnoreFeature == null || noCaster || !context.MaybeCaster.Descriptor.HasFact(this.IgnoreFeature);
             bool noImmunityFact = !this.CheckFact || (!noCaster && context.MaybeCaster.Descriptor.HasFact(this.FactToCheck));
             bool casterHasAlignment = !noCaster && context.MaybeCaster.Descriptor.Alignment.ValueRaw.HasComponent(this.Alignment);
             bool spellHasAlignment = context.SpellDescriptor.HasAnyFlag(this.Alignment.GetAlignmentDescriptor());
             return buffHasDescriptor && noImmunityBypassFeature && noImmunityFact && (casterHasAlignment || spellHasAlignment);
+        }
+
+        private SpellDescriptor GetWorkingImmunities() {
+            var rr = this.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().Entries();
+            if (rr != SpellDescriptor.None) {
+                return this.Descriptor.Value & ~this.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().Entries();
+            } else {
+                return this.Descriptor.Value;
+            }
         }
 
         public void OnEventAboutToTrigger(RuleCanApplyBuff evt) {

--- a/TabletopTweaks-Core/NewComponents/BuffDescriptorImmunityIgnore.cs
+++ b/TabletopTweaks-Core/NewComponents/BuffDescriptorImmunityIgnore.cs
@@ -1,0 +1,20 @@
+﻿using Kingmaker.Blueprints.Classes.Spells;
+using Kingmaker.Blueprints.JsonSystem;
+using Kingmaker.UnitLogic;
+using TabletopTweaks.Core.NewUnitParts;
+
+namespace TabletopTweaks.Core.NewComponents {
+    [TypeId("ebd1d39947344e15a478755d551b2a46")]
+    public class BuffDescriptorImmunityIgnore : UnitFactComponentDelegate {
+
+        public SpellDescriptorWrapper Descriptor;
+        public override void OnTurnOn() {
+            base.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().AddEntry(Descriptor, base.Fact);
+        }
+
+        public override void OnTurnOff() {
+            base.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().RemoveEntry(base.Fact);
+        }
+
+    }
+}

--- a/TabletopTweaks-Core/NewComponents/SpellDescriptorImmunityIgnore.cs
+++ b/TabletopTweaks-Core/NewComponents/SpellDescriptorImmunityIgnore.cs
@@ -1,0 +1,25 @@
+﻿using Kingmaker.Blueprints;
+using Kingmaker.Blueprints.Classes.Spells;
+using Kingmaker.Blueprints.Facts;
+using Kingmaker.Blueprints.JsonSystem;
+using Kingmaker.UnitLogic;
+using Kingmaker.UnitLogic.Parts;
+
+namespace TabletopTweaks.Core.NewComponents {
+
+    [AllowMultipleComponents]
+    [AllowedOn(typeof(BlueprintUnitFact), false)]
+    [TypeId("fa39b200501a498c95c16d36612f5bf7")]
+    public class SpellDescriptorImmunityIgnore :
+    UnitFactComponentDelegate {
+        public SpellDescriptorWrapper Descriptor;
+
+        public override void OnTurnOn() {
+            Owner.Ensure<UnitPartSpellResistance>().IgnoreImmunity(Descriptor);
+        }
+
+        public override void OnTurnOff() {
+            Owner.Ensure<UnitPartSpellResistance>().RestoreImmunity(Descriptor);
+        }
+    }
+}

--- a/TabletopTweaks-Core/NewUnitParts/UnitPartIgnoreBuffDescriptorImmunity.cs
+++ b/TabletopTweaks-Core/NewUnitParts/UnitPartIgnoreBuffDescriptorImmunity.cs
@@ -1,0 +1,115 @@
+﻿using HarmonyLib;
+using Kingmaker.Blueprints.Classes.Spells;
+using Kingmaker.EntitySystem;
+using Kingmaker.UnitLogic;
+using Kingmaker.UnitLogic.FactLogic;
+using Owlcat.Runtime.Core.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace TabletopTweaks.Core.NewUnitParts {
+    public class UnitPartIgnoreBuffDescriptorImmunity : UnitPart {
+        public void AddEntry(SpellDescriptor? descriptor, EntityFact source) {
+            if (descriptor == null) {
+                return;
+            }
+            ImmunityIgnoreEntry item = new ImmunityIgnoreEntry {
+                Descriptor = descriptor.Value,
+                Source = source
+            };
+            Descriptors.Add(item);
+        }
+
+        public void RemoveEntry(EntityFact source) {
+            Descriptors.RemoveAll(p => p.Source == source);
+            TryRemove();
+        }
+
+        private void TryRemove() {
+            if (!Descriptors.Any()) { this.RemoveSelf(); }
+        }
+
+        public bool HasEntry(SpellDescriptor category) {
+            return Descriptors.Any(p => p.Descriptor == category);
+        }
+
+        public SpellDescriptor Entries() {
+            SpellDescriptor result = SpellDescriptor.None;
+            foreach (var item in Descriptors) {
+                result |= item.Descriptor;
+            }
+            return result;
+        }
+
+        public List<ImmunityIgnoreEntry> Descriptors = new();
+
+        public class ImmunityIgnoreEntry {
+            public SpellDescriptor Descriptor;
+            public EntityFact Source;
+        }
+
+
+        [HarmonyPatch(typeof(BuffDescriptorImmunity))]
+        private static class BuffDescriptorImmunity_Patch {
+
+            /**
+             * Replaces this line
+             * 
+             * bool flag = this.Descriptor.HasAnyFlag(context.SpellDescriptor);
+             * 
+             * with this
+             * 
+             * bool flag = BuffDescriptorImmunity_Patch.GetWorkingImmunities(this).HasAnyFlag(context.SpellDescriptor);
+             */
+            [HarmonyPatch(nameof(BuffDescriptorImmunity.IsImmune)), HarmonyTranspiler]
+            static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions) {
+                try {
+                    var code = new List<CodeInstruction>(instructions);
+
+                    var fDescriptorFind = 0;
+                    FieldInfo descriptorField = AccessTools.Field(typeof(BuffDescriptorImmunity), nameof(BuffDescriptorImmunity.Descriptor));
+                    for (int i = 0; i < code.Count; i++) {
+                        if (code[i].LoadsField(descriptorField, true)) {
+                            fDescriptorFind = i;
+                            break;
+                        }
+                    }
+                    if (fDescriptorFind == 0) {
+                        throw new InvalidOperationException("Unable to find the insertion index for Descriptor field find.");
+                    }
+                    code[fDescriptorFind] = CodeInstruction.Call(typeof(BuffDescriptorImmunity_Patch), nameof(BuffDescriptorImmunity_Patch.GetWorkingImmunities));
+
+                    var mHasAnyFlagCall = 0;
+                    MethodInfo hasAnyFlagCall = AccessTools.Method(typeof(SpellDescriptorWrapper), nameof(SpellDescriptorWrapper.HasAnyFlag));
+                    for (int i = fDescriptorFind; i < code.Count; i++) {
+                        if (code[i].Calls(hasAnyFlagCall)) {
+                            mHasAnyFlagCall = i;
+                            break;
+                        }
+                    }
+
+                    if (mHasAnyFlagCall == 0) {
+                        throw new InvalidOperationException("Unable to find the insertion index for HasAnyFlag call.");
+                    }
+                    code[mHasAnyFlagCall] = CodeInstruction.Call(typeof(SpellDescriptorOperations), nameof(SpellDescriptorOperations.HasAnyFlag));
+
+                    return code;
+                } catch (Exception e) {
+                    LogChannel.Mods.Error($"BuffDescriptorImmunity.IsImmune Transpiler exception {e.Message}", e);
+                    return instructions;
+                }
+
+            }
+            static SpellDescriptor GetWorkingImmunities(BuffDescriptorImmunity bdi) {
+                var rr = bdi.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().Entries();
+                if (rr != SpellDescriptor.None) {
+                    return bdi.Descriptor.Value & ~bdi.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().Entries();
+                } else {
+                    return bdi.Descriptor.Value;
+                }
+            }
+        }
+    }
+}

--- a/TabletopTweaks-Core/TabletopTweaks-Core.csproj
+++ b/TabletopTweaks-Core/TabletopTweaks-Core.csproj
@@ -162,7 +162,10 @@
     <Compile Include="Config\Blueprints.cs" />
     <Compile Include="NewComponents\AddAdditionalWeaponDamageOnHit.cs" />
     <Compile Include="NewComponents\AddConditionalWeaponDamageBonus.cs" />
+    <Compile Include="NewComponents\BuffDescriptorImmunityIgnore.cs" />
     <Compile Include="NewComponents\OwlcatReplacements\AttackBonusAgainstTargetTTT.cs" />
+    <Compile Include="NewComponents\SpellDescriptorImmunityIgnore.cs" />
+    <Compile Include="NewUnitParts\UnitPartIgnoreBuffDescriptorImmunity.cs" />
     <Compile Include="Utilities\VenderTools.cs" />
     <EmbeddedResource Include="Config\Blueprints.json" />
     <Compile Include="Config\ICollapseableGroup.cs" />


### PR DESCRIPTION
Adds support (components + required inner changes) for ignoring spell descriptor and buff descriptor immunities. (I.e. fear immunities are suppressed under Antipaladin's Aura of Cowardice).