### PR TITLE
Clean up BuffDescriptorImmunityIgnore unit part properly

### DIFF
--- a/TabletopTweaks-Core/NewComponents/BuffDescriptorImmunityAgainstAlignment.cs
+++ b/TabletopTweaks-Core/NewComponents/BuffDescriptorImmunityAgainstAlignment.cs
@@ -60,9 +60,10 @@ namespace TabletopTweaks.Core.NewComponents {
         }
 
         private SpellDescriptor GetWorkingImmunities() {
-            var rr = this.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().Entries();
-            if (rr != SpellDescriptor.None) {
-                return this.Descriptor.Value & ~this.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().Entries();
+            var ignorePart = this.Owner.Get<UnitPartIgnoreBuffDescriptorImmunity>();
+            var ignoredDescriptors = ignorePart == null ? SpellDescriptor.None : ignorePart.Entries();
+            if (ignoredDescriptors != SpellDescriptor.None) {
+                return this.Descriptor.Value & ~ignoredDescriptors;
             } else {
                 return this.Descriptor.Value;
             }

--- a/TabletopTweaks-Core/NewUnitParts/UnitPartIgnoreBuffDescriptorImmunity.cs
+++ b/TabletopTweaks-Core/NewUnitParts/UnitPartIgnoreBuffDescriptorImmunity.cs
@@ -103,9 +103,10 @@ namespace TabletopTweaks.Core.NewUnitParts {
 
             }
             static SpellDescriptor GetWorkingImmunities(BuffDescriptorImmunity bdi) {
-                var rr = bdi.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().Entries();
-                if (rr != SpellDescriptor.None) {
-                    return bdi.Descriptor.Value & ~bdi.Owner.Ensure<UnitPartIgnoreBuffDescriptorImmunity>().Entries();
+                var ignorePart = bdi.Owner.Get<UnitPartIgnoreBuffDescriptorImmunity>();
+                var ignoredDescriptors = ignorePart == null ? SpellDescriptor.None : ignorePart.Entries();
+                if (ignoredDescriptors != SpellDescriptor.None) {
+                    return bdi.Descriptor.Value & ~ignoredDescriptors;
                 } else {
                     return bdi.Descriptor.Value;
                 }


### PR DESCRIPTION
- use .Get() instead of .Ensure() when checking so as not to add empty unit part to unit